### PR TITLE
Add support of llvm-15 (#99)

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
 endif()
 
 install(TARGETS codebrowser_generator RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-target_include_directories(codebrowser_generator PUBLIC ${CLANG_INCLUDE_DIRS})
+target_include_directories(codebrowser_generator SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 set_property(TARGET codebrowser_generator PROPERTY CXX_STANDARD 14)
 
 

--- a/generator/preprocessorcallback.h
+++ b/generator/preprocessorcallback.h
@@ -25,6 +25,9 @@
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Basic/Version.h>
 #include <clang/AST/Decl.h>
+#if CLANG_VERSION_MAJOR >= 15
+#include <llvm/ADT/Optional.h>
+#endif
 
 namespace clang {
 class Preprocessor;
@@ -60,10 +63,19 @@ public:
 #endif
         ) override;
 
-    bool FileNotFound(llvm::StringRef FileName, llvm::SmallVectorImpl<char> &RecoveryPath) override;
-    void InclusionDirective(clang::SourceLocation HashLoc, const clang::Token& IncludeTok, llvm::StringRef FileName,
-                            bool IsAngled, clang::CharSourceRange FilenameRange, const clang::FileEntry* File,
-                            llvm::StringRef SearchPath, llvm::StringRef RelativePath, const clang::Module* Imported
+    void InclusionDirective(clang::SourceLocation HashLoc,
+                            const clang::Token& IncludeTok,
+                            llvm::StringRef FileName,
+                            bool IsAngled,
+                            clang::CharSourceRange FilenameRange,
+#if CLANG_VERSION_MAJOR >= 15
+                            llvm::Optional<clang::FileEntryRef> File,
+#else
+                            const clang::FileEntry* File,
+#endif
+                            llvm::StringRef SearchPath,
+                            llvm::StringRef RelativePath,
+                            const clang::Module* Imported
 #if CLANG_VERSION_MAJOR >= 7
                             , clang::SrcMgr::CharacteristicKind
 #endif


### PR DESCRIPTION
* Remove PPCallbacks::FileNotFound() override

Since according to [1] it had been broken anyway.

  [1]: https://github.com/llvm/llvm-project/commit/7a124f4859d5c4093467abc2e734f8ab15e78cc6

* Include clang directories with -isystem/SYSTEM

This is to suppress errors like:

    In file included from /workdir/woboq_codebrowser/generator/commenthandler.cpp:27:
    In file included from /usr/lib/llvm-15/include/clang/AST/CommentParser.h:16:
    /usr/lib/llvm-15/include/clang/AST/Comment.h:149:54: warning: arithmetic between different enumeration types ('clang::comments::Comment::(unnamed enum at /usr/lib/llvm-15/include/clang/AST/Comment.h:66:3)' and 'clang::comments::CommandInfo::(unnamed enum at /usr/lib/llvm-15/include/clang/AST/CommentCommandTraits.h:43:3)') is deprecated [-Wdeprecated-anon-enum-enum-conversion]
      enum { NumBlockCommandCommentBits = NumCommentBits +
                                          ~~~~~~~~~~~~~~ ^

Refs: https://s3.amazonaws.com/clickhouse-test-reports/41046/f1df5fb537b97fa6e67db121995d72ecdf797cf7/push_to_dockerhub_aarch64.html

* Support llvm-15 for PreprocessorCallback::InclusionDirective()

Refs: https://github.com/llvm/llvm-project/commit/d79ad2f1dbc2d